### PR TITLE
feat: 新增 Dark Mode 深色模式功能

### DIFF
--- a/docs/architecture-design.md
+++ b/docs/architecture-design.md
@@ -481,7 +481,7 @@ export default function Header() {
       </a>
       
       <button 
-        className="btn icon-btn"
+        className="icon-btn"
         onClick={handleViewToggle}
         aria-label={isCalendarView ? "Switch to list view" : "Switch to calendar view"}
       >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,16 @@
+import { useEffect } from 'react';
+
+import { useTheme } from './hooks/useTheme';
 import Router from './routes/Router';
 import PWABadge from './PWABadge';
 
 function App() {
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
   return (
     <>
       <Router />

--- a/src/components/calendar/CalendarHeader.tsx
+++ b/src/components/calendar/CalendarHeader.tsx
@@ -39,7 +39,7 @@ export default function CalendarHeader({
       <div className="flex gx-sm">
         <button
           type="button"
-          className={`btn icon-btn ${styles['nav-button']}`}
+          className={`icon-btn ${styles['nav-button']}`}
           onClick={onPreviousMonth}
           aria-label={t('calendar.previousMonth')}
         >
@@ -47,7 +47,7 @@ export default function CalendarHeader({
         </button>
         <button
           type="button"
-          className={`btn icon-btn ${styles['nav-button']}`}
+          className={`icon-btn ${styles['nav-button']}`}
           onClick={onNextMonth}
           aria-label={t('calendar.nextMonth')}
         >

--- a/src/components/calendar/CalendarWorkoutModal.tsx
+++ b/src/components/calendar/CalendarWorkoutModal.tsx
@@ -63,7 +63,7 @@ export default function CalendarWorkoutModal({
           <h3 id="modal-title">{formatDisplayDate(selectedDate)}</h3>
           <button
             type="button"
-            className="btn icon-btn"
+            className="icon-btn"
             onClick={onClose}
             aria-label={t('common.close')}
           >

--- a/src/components/feature/ExerciseCard.tsx
+++ b/src/components/feature/ExerciseCard.tsx
@@ -35,7 +35,7 @@ export default function ExerciseCard({
             {onEdit && (
               <button
                 type="button"
-                className="btn icon-btn icon-btn--primary"
+                className="icon-btn icon-btn--primary"
                 onClick={() => onEdit(exercise)}
               >
                 <EditIcon width={18} height={18} fill="currentColor" />
@@ -44,7 +44,7 @@ export default function ExerciseCard({
             {onDelete && (
               <button
                 type="button"
-                className="btn icon-btn icon-btn--primary"
+                className="icon-btn icon-btn--primary"
                 onClick={() => onDelete(exercise)}
               >
                 <DeleteIcon width={18} height={18} fill="currentColor" />

--- a/src/components/feature/WorkoutCard.module.scss
+++ b/src/components/feature/WorkoutCard.module.scss
@@ -3,6 +3,12 @@
 .workout-card {
   max-width: min(400px, 100dvw - variables.$spacing-md * 2);
   margin: 0 auto;
+  
+  background-color: variables.$bg-white;
+
+  [data-theme='dark'] & {
+    background-color: variables.$bg-light;
+  }
 }
 
 .exercise {

--- a/src/components/feature/WorkoutCard.module.scss
+++ b/src/components/feature/WorkoutCard.module.scss
@@ -1,7 +1,7 @@
 @use "../../styles/abstracts/variables";
 
 .workout-card {
-  max-width: min(400px, 100dvw - variables.$spacing-md * 2);
+  width: min(400px, 100dvw - variables.$spacing-md * 2);
   margin: 0 auto;
   
   background-color: variables.$bg-white;

--- a/src/components/feature/WorkoutCard.tsx
+++ b/src/components/feature/WorkoutCard.tsx
@@ -12,7 +12,7 @@ export default function WorkoutCard({ workout }: { workout: IWorkout }) {
     <Card className={styles['workout-card']}>
       <CardHeader className="flex align-center justify-between pb-md bg-primary">
         <h3>{workout.description}</h3>
-        <button className="btn icon-btn icon-btn--primary">
+        <button className="icon-btn icon-btn--primary ml-xl">
           <EditIcon width={18} height={18} fill="currentColor" />
         </button>
       </CardHeader>

--- a/src/components/form/Switch.module.scss
+++ b/src/components/form/Switch.module.scss
@@ -1,0 +1,75 @@
+@use '../../styles/abstracts/variables' as *;
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 48px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  outline: none;
+  transition: opacity $transition-fast $ease-in-out;
+
+  &:focus-visible {
+    .switch__track {
+      box-shadow: 0 0 0 3px rgba($primary-green, 0.2);
+    }
+  }
+
+  &--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &__track {
+    position: absolute;
+    width: 100%;
+    height: 20px;
+    background-color: color-mix(in srgb, var(--text-dark) 30%, transparent);
+    border-radius: 10px;
+    transition: background-color $transition-normal $ease-in-out;
+  }
+
+  &__thumb {
+    position: absolute;
+    left: 4px;
+    width: 16px;
+    height: 16px;
+    background-color: $bg-white;
+    border-radius: 50%;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: transform $transition-normal $ease-in-out,
+                background-color $transition-normal $ease-in-out;
+    transform: translateX(0);
+  }
+
+  &--checked {
+    .switch__track {
+      background-color: $primary-green;
+    }
+
+    .switch__thumb {
+      transform: translateX(20px);
+    }
+  }
+
+  &:hover:not(&--disabled) {
+    .switch__track {
+      background-color: color-mix(in srgb, var(--text-dark) 40%, transparent);
+    }
+
+    &.switch--checked .switch__track {
+      background-color: $light-green;
+    }
+  }
+
+  &:active:not(&--disabled) {
+    .switch__thumb {
+      width: 18px;
+    }
+  }
+}
+

--- a/src/components/form/Switch.module.scss.d.ts
+++ b/src/components/form/Switch.module.scss.d.ts
@@ -1,0 +1,8 @@
+declare const classNames: {
+  readonly switch: "switch";
+  readonly switch__track: "switch__track";
+  readonly "switch--disabled": "switch--disabled";
+  readonly switch__thumb: "switch__thumb";
+  readonly "switch--checked": "switch--checked";
+};
+export = classNames;

--- a/src/components/form/Switch.tsx
+++ b/src/components/form/Switch.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import styles from './Switch.module.scss';
+
+interface ISwitchProps {
+  id?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Switch component for toggling between two states (e.g., light/dark mode)
+ */
+const Switch: React.FC<ISwitchProps> = ({
+  id,
+  checked,
+  onChange,
+  disabled = false,
+  ariaLabel,
+  className,
+}) => {
+  const handleToggle = () => {
+    if (disabled) return;
+    onChange(!checked);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onChange(!checked);
+    }
+  };
+
+  return (
+    <button
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      aria-disabled={disabled ? 'true' : undefined}
+      className={`${styles.switch} ${checked ? styles['switch--checked'] : ''} ${
+        disabled ? styles['switch--disabled'] : ''
+      } ${className || ''}`}
+      onClick={handleToggle}
+      onKeyDown={handleKeyDown}
+    >
+      <span className={styles.switch__track} />
+      <span className={styles.switch__thumb} />
+    </button>
+  );
+};
+
+export default Switch;

--- a/src/components/layouts/Header.module.scss
+++ b/src/components/layouts/Header.module.scss
@@ -31,8 +31,8 @@
   }
 }
 
-.view-toggle-btn {
-  display: flex;
+.header-icon-btn {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 40px;

--- a/src/components/layouts/Header.module.scss.d.ts
+++ b/src/components/layouts/Header.module.scss.d.ts
@@ -3,7 +3,8 @@ declare const classNames: {
   readonly "header-content": "header-content";
   readonly "header-logo": "header-logo";
   readonly "header-actions": "header-actions";
-  readonly "view-toggle-btn": "view-toggle-btn";
+  readonly "header-icon-btn": "header-icon-btn";
   readonly "icon-active": "icon-active";
+  readonly "view-toggle-btn": "view-toggle-btn";
 };
 export = classNames;

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -65,7 +65,6 @@ export default function Header() {
           >
             <SettingsIcon width={24} height={24} fill="currentColor" />
           </button>
-          {/* TODO: Dark Mode Button */}
         </div>
       </div>
     </header>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -44,7 +44,7 @@ export default function Header() {
         <div className={styles['header-actions']}>
           <button
             type="button"
-            className={`btn icon-btn ${styles['view-toggle-btn']}`}
+            className={`icon-btn ${styles['header-icon-btn']}`}
             onClick={handleViewToggle}
             aria-label={
               isCalendarView ? 'Switch to list view' : 'Switch to calendar view'
@@ -60,7 +60,7 @@ export default function Header() {
           </button>
           <button
             type="button"
-            className="btn icon-btn"
+            className={`icon-btn ${styles['header-icon-btn']}`}
             onClick={() => navigate('/settings')}
           >
             <SettingsIcon width={24} height={24} fill="currentColor" />

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+export type TTheme = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'app_theme';
+
+/**
+ * Hook to manage theme state (light/dark mode)
+ * Persists theme preference to localStorage and applies it to the document
+ */
+export function useTheme() {
+  const [theme, setTheme] = useState<TTheme>(() => {
+    // Try to get theme from localStorage
+    try {
+      const stored = localStorage.getItem(THEME_STORAGE_KEY);
+      if (stored === 'light' || stored === 'dark') {
+        return stored;
+      }
+    } catch (error) {
+      console.error('Error reading theme from localStorage:', error);
+    }
+
+    // Default to light mode
+    return 'light';
+  });
+
+  useEffect(() => {
+    // Apply theme to document root
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+
+    // Save to localStorage
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch (error) {
+      console.error('Error saving theme to localStorage:', error);
+    }
+  }, [theme]);
+
+  const toggleTheme = (checked?: boolean) => {
+    if (checked !== undefined) {
+      setTheme(checked ? 'dark' : 'light');
+    } else {
+      setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+    }
+  };
+
+  return { theme, setTheme, toggleTheme };
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -21,6 +21,7 @@ const resources = {
       },
       settings: {
         language: 'Language',
+        theme: 'Dark Mode',
         version: 'Version',
       },
       calendar: {
@@ -153,6 +154,7 @@ const resources = {
       },
       settings: {
         language: '語言',
+        theme: '深色模式',
         version: '版本',
       },
       calendar: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,19 @@ import App from './App.tsx';
 
 import './styles/main.scss';
 
+const initializeTheme = () => {
+  try {
+    const stored = localStorage.getItem('app_theme');
+    const theme = stored === 'dark' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', theme);
+  } catch (error) {
+    console.error('Error initializing theme:', error);
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+};
+
+initializeTheme();
+
 createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/src/routes/Home.module.scss
+++ b/src/routes/Home.module.scss
@@ -15,6 +15,10 @@
   font-weight: variables.$font-weight-bold;
   text-align: center;
   width: fit-content;
+
+  [data-theme='dark'] & {
+    background-color: #eee2;
+  }
 }
 
 .floating-action-button {

--- a/src/routes/Home.module.scss
+++ b/src/routes/Home.module.scss
@@ -37,5 +37,9 @@
 
   &:hover {
     background-color: variables.$dark-green;
+
+    [data-theme='dark'] & {
+      background-color: variables.$light-green;
+    }
   }
 }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -42,7 +42,7 @@ export default function Home() {
     <div>
       <Header />
       <main className={`main ${styles['home-main']}`}>
-        <ul>
+        <ul className="flex flex-column align-center">
           {groupedWorkoutByDate.map(({ workout, date }) => (
             <li key={date}>
               <h2 className={styles['date-chip']}>{date}</h2>

--- a/src/routes/Settings.module.scss
+++ b/src/routes/Settings.module.scss
@@ -29,6 +29,12 @@
     padding: $spacing-md 0;
   }
 
+  &__switch-wrapper {
+    margin-top: $spacing-xs;
+    display: flex;
+    align-items: center;
+  }
+
   // Material Design 风格的 select 容器
   &__select-wrapper {
     position: relative;
@@ -60,7 +66,7 @@
     width: 100%;
     padding: $spacing-md $spacing-xl $spacing-md $spacing-sm;
     border: none;
-    border-bottom: 1px solid rgba($text-dark, 0.42);
+    border-bottom: 1px solid color-mix(in srgb, var(--text-dark) 42%, transparent);
     border-radius: 0;
     font-size: $font-size-base;
     color: $text-dark;
@@ -78,25 +84,25 @@
     background-repeat: no-repeat;
     background-size: 24px;
     padding-right: 48px;
-
+    
     // Hover 状态 - Material Design ripple effect 的替代
     &:hover {
-      background-color: rgba($text-dark, 0.04);
-      border-bottom-color: rgba($text-dark, 0.87);
+      background-color: color-mix(in srgb, var(--text-dark) 4%, transparent);
+      border-bottom-color: color-mix(in srgb, var(--text-dark) 87%, transparent);
     }
-
+    
     // Focus 状态 - Material Design 强调色（下划线由 wrapper 的 ::after 处理）
     &:focus {
       outline: none;
       border-bottom-color: $primary-green;
-      background-color: rgba($primary-green, 0.04);
+      background-color: color-mix(in srgb, $primary-green 4%, transparent);
     }
-
+    
     // Active 状态
     &:active {
-      background-color: rgba($primary-green, 0.08);
+      background-color: color-mix(in srgb, $primary-green 8%, transparent);
     }
-
+    
     // Material Design 的选项样式
     option {
       padding: $spacing-md;

--- a/src/routes/Settings.module.scss.d.ts
+++ b/src/routes/Settings.module.scss.d.ts
@@ -3,6 +3,7 @@ declare const classNames: {
   readonly settings__item: "settings__item";
   readonly settings__label: "settings__label";
   readonly settings__version: "settings__version";
+  readonly "settings__switch-wrapper": "settings__switch-wrapper";
   readonly "settings__select-wrapper": "settings__select-wrapper";
   readonly settings__select: "settings__select";
   readonly "settings__ripple-container": "settings__ripple-container";

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Switch from '~/components/form/Switch';
 import SubPageHeader from '~/components/layouts/SubPageHeader';
+import { useTheme } from '~/hooks/useTheme';
 
 import styles from './Settings.module.scss';
 
@@ -14,6 +16,7 @@ export default function Settings() {
   const { t, i18n } = useTranslation();
   const version = APP_VERSION;
   const [currentLang, setCurrentLang] = useState(i18n.language);
+  const { theme, toggleTheme } = useTheme();
 
   // 监听语言变化
   useEffect(() => {
@@ -68,6 +71,18 @@ export default function Settings() {
                   </option>
                 ))}
               </select>
+            </div>
+          </li>
+          <li className={styles['settings__item']}>
+            <label className={styles['settings__label']}>
+              {t('settings.theme')}
+            </label>
+            <div className={styles['settings__switch-wrapper']}>
+              <Switch
+                checked={theme === 'dark'}
+                onChange={toggleTheme}
+                ariaLabel={t('settings.theme')}
+              />
             </div>
           </li>
           <li className={styles['settings__item']}>

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -19,7 +19,7 @@ $gap-map: (
 // 顏色系統 (Color System)
 // =============================================================================
 
-// 主要品牌色彩 (Primary Brand Colors)
+// 主要品牌色彩 (Primary Brand Colors) - 在 light 和 dark mode 中保持一致
 $primary-green: #007852;
 $light-green: #00a07a;
 $dark-green: #005a3e;
@@ -37,41 +37,104 @@ $red: #DB4437;
 $light-red: #f38686;
 $dark-red: #B72D29;
 
-// 背景色彩 (Background Colors)
-$bg-white: #ffffff;
-$bg-light: #f7f7f8;
-$bg-grey: #f0f0f0;
-$bg-light-grey: #f9f9f9;
-$bg-grey-hover: #f5f5f5;
-$bg-primary: #f5f9f7;
-$bg-sub-green: #d5e1dd;
-$bg-light-green: #f5f9f7;
-$bg-dropdown: #ffffff;
-$bg-selected: #ebfff5;
+// =============================================================================
+// 主題顏色變數 (Theme Color Variables)
+// 使用 CSS 變數以支持動態主題切換
+// =============================================================================
 
-// 文字色彩 (Text Colors)
-$text-dark: #343541;
-$text-sub-dark: #666;
-$text-white: #ffffff;
-$text-grey: #6e6e80;
-$text-light-grey: #acacbe;
+:root {
+  // Light Mode Colors (預設)
+  --bg-white: #ffffff;
+  --bg-light: #f7f7f8;
+  --bg-grey: #f0f0f0;
+  --bg-light-grey: #f9f9f9;
+  --bg-grey-hover: #f5f5f5;
+  --bg-primary: #f5f9f7;
+  --bg-sub-green: #d5e1dd;
+  --bg-light-green: #f5f9f7;
+  --bg-dropdown: #ffffff;
+  --bg-selected: #ebfff5;
+  
+  --text-dark: #343541;
+  --text-sub-dark: #666;
+  --text-white: #ffffff;
+  --text-grey: #6e6e80;
+  --text-light-grey: #acacbe;
+  
+  --border-color: #e5e5e5;
+  --border-light-green: #e6f3ed;
+  
+  --button-hover: #ebfff5;
+}
 
-// 邊框色彩 (Border Colors)
-$border-color: #e5e5e5;
-$border-light-green: #e6f3ed;
+[data-theme='dark'] {
+  // Dark Mode Colors
+  --bg-white: #1e1e1e;
+  --bg-light: #2a2a2a;
+  --bg-grey: #333333;
+  --bg-light-grey: #2d2d2d;
+  --bg-grey-hover: #3a3a3a;
+  --bg-primary: #2d4035;
+  --bg-sub-green: #2a3a32;
+  --bg-light-green: #2d4035;
+  --bg-dropdown: #2a2a2a;
+  --bg-selected: #1a3d2e;
+  
+  --text-dark: #e0e0e0;
+  --text-sub-dark: #b0b0b0;
+  --text-white: #ffffff;
+  --text-grey: #a0a0a0;
+  --text-light-grey: #808080;
+  
+  --border-color: #404040;
+  --border-light-green: #2a4a3a;
+  
+  --button-hover: #1a3d2e;
+}
 
-// 互動色彩 (Interactive Colors)
-$button-hover: #ebfff5;
+// SCSS 變數映射到 CSS 變數 (用於向後兼容)
+$bg-white: var(--bg-white);
+$bg-light: var(--bg-light);
+$bg-grey: var(--bg-grey);
+$bg-light-grey: var(--bg-light-grey);
+$bg-grey-hover: var(--bg-grey-hover);
+$bg-primary: var(--bg-primary);
+$bg-sub-green: var(--bg-sub-green);
+$bg-light-green: var(--bg-light-green);
+$bg-dropdown: var(--bg-dropdown);
+$bg-selected: var(--bg-selected);
+
+$text-dark: var(--text-dark);
+$text-sub-dark: var(--text-sub-dark);
+$text-white: var(--text-white);
+$text-grey: var(--text-grey);
+$text-light-grey: var(--text-light-grey);
+
+$border-color: var(--border-color);
+$border-light-green: var(--border-light-green);
+
+$button-hover: var(--button-hover);
 
 // =============================================================================
 // 陰影系統 (Shadow System)
 // =============================================================================
+// Light mode shadows
 $dropdown-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
 $popup-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
 $card-shadow: 0 4px 9px rgba(0, 0, 0, 0.2);
 $input-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 $button-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 $sidebar-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+
+// Dark mode shadows (更深的陰影以增強對比)
+[data-theme='dark'] {
+  --dropdown-shadow: 0 -4px 20px rgba(0, 0, 0, 0.4);
+  --popup-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
+  --card-shadow: 0 4px 9px rgba(0, 0, 0, 0.5);
+  --input-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  --button-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  --sidebar-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
+}
 
 // =============================================================================
 // 圓角系統 (Border Radius System)

--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -13,6 +13,10 @@
 
   &:hover {
     background-color: variables.$bg-grey;
+
+    [data-theme='dark'] & {
+      background-color: variables.$bg-grey-hover;
+    }
   }
 
   &--sm {
@@ -26,6 +30,10 @@
     &:hover {
       color: variables.$bg-white;
       background-color: variables.$primary-green;
+
+      [data-theme='dark'] & {
+        background-color: variables.$light-green;
+      }
     }
   }
 
@@ -54,6 +62,10 @@
   
       &:hover {
         background-color: variables.$dark-green;
+
+        [data-theme='dark'] & {
+          background-color: variables.$light-green;
+        }
       }
     }
 
@@ -82,6 +94,10 @@
 
     &:hover {
       background-color: variables.$bg-light;
+
+      [data-theme='dark'] & {
+        background-color: variables.$bg-grey-hover;
+      }
     }
 
     &--primary {
@@ -91,6 +107,10 @@
       &:hover {
         background-color: variables.$primary-green;
         color: variables.$bg-white;
+
+        [data-theme='dark'] & {
+          background-color: variables.$light-green;
+        }
       }
     }
 

--- a/src/styles/layout/_card.scss
+++ b/src/styles/layout/_card.scss
@@ -8,6 +8,7 @@
   flex-direction: column;
   height: 100%;
   min-height: 0;
+  overflow: hidden;
 
   &--auto-height {
     height: auto;


### PR DESCRIPTION
## 功能描述
此 PR 新增深色模式（Dark Mode）功能，讓使用者可以在設定頁面中切換淺色/深色主題。

## 實作內容
- ✅ 新增 `useTheme` hook 管理主題狀態
- ✅ 實作 CSS 變數系統支援動態主題切換
- ✅ 新增 Switch 開關組件
- ✅ 在設定頁面新增主題切換功能
- ✅ 更新所有組件樣式以支援深色模式
- ✅ 主題偏好設定會儲存到 localStorage

## 技術細節
- 使用 CSS 變數（CSS Variables）實作主題系統
- 透過 `data-theme` 屬性切換主題
- 主題設定會持久化儲存
- 應用程式啟動時會自動載入使用者偏好主題

## 相關 Issue
Closes #15

## 檢查清單
- [x] 程式碼已通過測試
- [x] 已更新相關樣式檔案
- [x] 功能在淺色和深色模式下皆正常運作